### PR TITLE
Change flatHeights on Android to account for when text gets truncated

### DIFF
--- a/android/src/main/java/com/github/amarcruz/rntextsize/RNTextSizeModule.java
+++ b/android/src/main/java/com/github/amarcruz/rntextsize/RNTextSizeModule.java
@@ -185,18 +185,6 @@ class RNTextSizeModule extends ReactContextBaseJavaModule {
     }
 
     /**
-     * Retrieves heights of each entry in an array of strings rendered with the same style. This
-     * also returns an array of whether each text has an ellipsis.
-     *
-     * https://stackoverflow.com/questions/3654321/measuring-text-height-to-be-drawn-on-canvas-android
-     */
-    @SuppressWarnings("unused")
-    @ReactMethod
-    public void flatHeightsWithHasEllipsisOnAndroid(@Nullable final ReadableMap specs, final Promise promise) {
-        flatHeightsInner(specs, promise, FlatHeightsMode.heightsWithHasEllipsisOnAndroid);
-    }
-
-    /**
      * See https://material.io/design/typography/#type-scale
      */
     @SuppressWarnings("unused")
@@ -292,7 +280,6 @@ class RNTextSizeModule extends ReactContextBaseJavaModule {
     private enum FlatHeightsMode {
         heights,
         sizes,
-        heightsWithHasEllipsisOnAndroid,
     }
 
     private void flatHeightsInner(@Nullable final ReadableMap specs, final Promise promise, FlatHeightsMode mode) {
@@ -312,7 +299,6 @@ class RNTextSizeModule extends ReactContextBaseJavaModule {
         final boolean includeFontPadding = conf.includeFontPadding;
 
         final WritableArray heights = Arguments.createArray();
-        final WritableArray hasEllipsisOnAndroid = Arguments.createArray();
         final WritableArray widths = Arguments.createArray();
 
         final SpannableStringBuilder sb = new SpannableStringBuilder(" ");
@@ -341,13 +327,21 @@ class RNTextSizeModule extends ReactContextBaseJavaModule {
                 // Reset the SB text, the attrs will expand to its full length
                 sb.replace(0, sb.length(), text);
                 layout = buildStaticLayout(conf, includeFontPadding, sb, textPaint, (int) width);
-                heights.pushDouble(layout.getHeight() / density);
 
+                float height = layout.getHeight() / density;
 
-                if (mode == FlatHeightsMode.heightsWithHasEllipsisOnAndroid || mode == FlatHeightsMode.sizes) {
+                if (conf.numberOfLines != null || mode == FlatHeightsMode.sizes) {
                     final int lineCount = layout.getLineCount();
-                    boolean lastLineHasEllipsis = layout.getEllipsisCount(lineCount - 1) > 0;
-                    hasEllipsisOnAndroid.pushBoolean(lastLineHasEllipsis);
+
+                    if (conf.numberOfLines != null) {
+                        boolean lastLineHasEllipsis = layout.getEllipsisCount(lineCount - 1) > 0;
+                        // For unknown reasons, the text will be 2 subpixels shorter if truncated
+                        // due to numberOfLines. See the lines mentioning `numberOfLines` in the
+                        // TextHeights stories: this logic was created for those cases.
+                        if (lastLineHasEllipsis) {
+                            height -= 2 / density;
+                        }
+                    }
 
                     if (mode == FlatHeightsMode.sizes) {
                         float measuredWidth = 0;
@@ -357,26 +351,40 @@ class RNTextSizeModule extends ReactContextBaseJavaModule {
                         widths.pushDouble(measuredWidth / density);
                     }
                 }
+
+                heights.pushDouble(height);
             }
 
             switch (mode) {
                 case sizes: {
                     final WritableMap output = Arguments.createMap();
+                    // We output an object with 3 arrays instead of an array of
+                    // objects because it's much faster.
+                    //
+                    // Changing this output to arrays of objects quadrupled the
+                    // running time of flatSizes: 1000 iterations of the
+                    // following code went from 13ms to 47ms each.
+                    //
+                    // ```ts
+                    // const heightsParams: TSHeightsParams = {
+                    //   text: _.times(
+                    //     20,
+                    //     () =>
+                    //       'This is some text that is quie long. It should wrap onto a few lines',
+                    //   ),
+                    //   ...defaultTextStyle,
+                    //   width: 150,
+                    // };
+                    //
+                    // await TextSize.flatSizes(heightsParams);
+                    // ```
                     output.putArray("widths", widths);
                     output.putArray("heights", heights);
-                    output.putArray("hasEllipsisOnAndroid", hasEllipsisOnAndroid);
                     promise.resolve(output);
                     break;
                 }
                 case heights: {
                     promise.resolve(heights);
-                    break;
-                }
-                case heightsWithHasEllipsisOnAndroid: {
-                    final WritableMap output = Arguments.createMap();
-                    output.putArray("heights", heights);
-                    output.putArray("hasEllipsisOnAndroid", hasEllipsisOnAndroid);
-                    promise.resolve(output);
                     break;
                 }
             }

--- a/android/src/main/java/com/github/amarcruz/rntextsize/RNTextSizeModule.java
+++ b/android/src/main/java/com/github/amarcruz/rntextsize/RNTextSizeModule.java
@@ -370,7 +370,7 @@ class RNTextSizeModule extends ReactContextBaseJavaModule {
                     //   text: _.times(
                     //     20,
                     //     () =>
-                    //       'This is some text that is quie long. It should wrap onto a few lines',
+                    //       'This is some text that is quite long. It should wrap onto a few lines',
                     //   ),
                     //   ...defaultTextStyle,
                     //   width: 150,

--- a/android/src/main/java/com/github/amarcruz/rntextsize/RNTextSizeModule.java
+++ b/android/src/main/java/com/github/amarcruz/rntextsize/RNTextSizeModule.java
@@ -6,7 +6,6 @@ import android.graphics.Typeface;
 import android.os.Build;
 import android.text.BoringLayout;
 import android.text.Layout;
-import android.text.SpannableString;
 import android.text.SpannableStringBuilder;
 import android.text.StaticLayout;
 import android.text.TextPaint;
@@ -171,7 +170,7 @@ class RNTextSizeModule extends ReactContextBaseJavaModule {
     @SuppressWarnings("unused")
     @ReactMethod
     public void flatSizes(@Nullable final ReadableMap specs, final Promise promise) {
-        flatHeightsInner(specs, promise, true);
+        flatHeightsInner(specs, promise, FlatHeightsMode.sizes);
     }
 
     /**
@@ -182,7 +181,19 @@ class RNTextSizeModule extends ReactContextBaseJavaModule {
     @SuppressWarnings("unused")
     @ReactMethod
     public void flatHeights(@Nullable final ReadableMap specs, final Promise promise) {
-        flatHeightsInner(specs, promise, false);
+        flatHeightsInner(specs, promise, FlatHeightsMode.heights);
+    }
+
+    /**
+     * Retrieves heights of each entry in an array of strings rendered with the same style. This
+     * also returns an array of whether each text has an ellipsis.
+     *
+     * https://stackoverflow.com/questions/3654321/measuring-text-height-to-be-drawn-on-canvas-android
+     */
+    @SuppressWarnings("unused")
+    @ReactMethod
+    public void flatHeightsWithHasEllipsisOnAndroid(@Nullable final ReadableMap specs, final Promise promise) {
+        flatHeightsInner(specs, promise, FlatHeightsMode.heightsWithHasEllipsisOnAndroid);
     }
 
     /**
@@ -278,7 +289,13 @@ class RNTextSizeModule extends ReactContextBaseJavaModule {
     //
     // ============================================================================
 
-    private void flatHeightsInner(@Nullable final ReadableMap specs, final Promise promise, boolean includeWidths) {
+    private enum FlatHeightsMode {
+        heights,
+        sizes,
+        heightsWithHasEllipsisOnAndroid,
+    }
+
+    private void flatHeightsInner(@Nullable final ReadableMap specs, final Promise promise, FlatHeightsMode mode) {
         final RNTextSizeConf conf = getConf(specs, promise, true);
         if (conf == null) {
             return;
@@ -293,9 +310,9 @@ class RNTextSizeModule extends ReactContextBaseJavaModule {
         final float density = getCurrentDensity();
         final float width = conf.getWidth(density);
         final boolean includeFontPadding = conf.includeFontPadding;
-        final int textBreakStrategy = conf.getTextBreakStrategy();
 
         final WritableArray heights = Arguments.createArray();
+        final WritableArray hasEllipsisOnAndroid = Arguments.createArray();
         final WritableArray widths = Arguments.createArray();
 
         final SpannableStringBuilder sb = new SpannableStringBuilder(" ");
@@ -326,23 +343,42 @@ class RNTextSizeModule extends ReactContextBaseJavaModule {
                 layout = buildStaticLayout(conf, includeFontPadding, sb, textPaint, (int) width);
                 heights.pushDouble(layout.getHeight() / density);
 
-                if (includeWidths) {
+
+                if (mode == FlatHeightsMode.heightsWithHasEllipsisOnAndroid || mode == FlatHeightsMode.sizes) {
                     final int lineCount = layout.getLineCount();
-                    float measuredWidth = 0;
-                    for (int i = 0; i < lineCount; i++) {
-                        measuredWidth = Math.max(measuredWidth, layout.getLineMax(i));
+                    boolean lastLineHasEllipsis = layout.getEllipsisCount(lineCount - 1) > 0;
+                    hasEllipsisOnAndroid.pushBoolean(lastLineHasEllipsis);
+
+                    if (mode == FlatHeightsMode.sizes) {
+                        float measuredWidth = 0;
+                        for (int i = 0; i < lineCount; i++) {
+                            measuredWidth = Math.max(measuredWidth, layout.getLineMax(i));
+                        }
+                        widths.pushDouble(measuredWidth / density);
                     }
-                    widths.pushDouble(measuredWidth / density);
                 }
             }
 
-            if (includeWidths) {
-                final WritableMap output = Arguments.createMap();
-                output.putArray("widths", widths);
-                output.putArray("heights", heights);
-                promise.resolve(output);
-            } else {
-                promise.resolve(heights);
+            switch (mode) {
+                case sizes: {
+                    final WritableMap output = Arguments.createMap();
+                    output.putArray("widths", widths);
+                    output.putArray("heights", heights);
+                    output.putArray("hasEllipsisOnAndroid", hasEllipsisOnAndroid);
+                    promise.resolve(output);
+                    break;
+                }
+                case heights: {
+                    promise.resolve(heights);
+                    break;
+                }
+                case heightsWithHasEllipsisOnAndroid: {
+                    final WritableMap output = Arguments.createMap();
+                    output.putArray("heights", heights);
+                    output.putArray("hasEllipsisOnAndroid", hasEllipsisOnAndroid);
+                    promise.resolve(output);
+                    break;
+                }
             }
         } catch (Exception e) {
             promise.reject(E_UNKNOWN_ERROR, e);

--- a/index.d.ts
+++ b/index.d.ts
@@ -205,7 +205,7 @@ declare module "react-native-text-size" {
      *   text: _.times(
      *     20,
      *     () =>
-     *       'This is some text that is quie long. It should wrap onto a few lines',
+     *       'This is some text that is quite long. It should wrap onto a few lines',
      *   ),
      *   ...defaultTextStyle,
      *   width: 150,

--- a/index.d.ts
+++ b/index.d.ts
@@ -190,25 +190,31 @@ declare module "react-native-text-size" {
     heights: number[];
   }
 
-  export interface TSFlatHeightWithHasEllipsisOnAndroid {
-    heights: number[];
-    /** Only set on Android; will always be undefined on iOS */
-    hasEllipsisOnAndroid?: boolean[];
-  }
-
   interface TextSizeStatic {
     measure(params: TSMeasureParams): Promise<TSMeasureResult>;
+
+    /**
+     * On Android, we benchmarked this to take 1.55x the time of flatHeights.
+     * Measuring the sizes for the following input 1000 times took 13.38ms vs.
+     * 8.6ms.
+     * 
+     * On iOS, this should run at roughly the same speed as flatHeights.
+     * 
+     * ```
+     * {
+     *   text: _.times(
+     *     20,
+     *     () =>
+     *       'This is some text that is quie long. It should wrap onto a few lines',
+     *   ),
+     *   ...defaultTextStyle,
+     *   width: 150,
+     * };
+     * ```
+     */
     flatSizes(params: TSHeightsParams): Promise<TSFlatSizes>;
     flatHeights(params: TSHeightsParams): Promise<number[]>;
-    /**
-     * On Android, React Native renders text with slightly less space when
-     * it gets truncated with an ellipsis. As such, we add an alternate output
-     * that tells us whether each piece of text had an ellipsis added when it
-     * was rendered.
-     */
-    flatHeightsWithHasEllipsisOnAndroid(
-      params: TSHeightsParams,
-    ): Promise<TSFlatHeightWithHasEllipsisOnAndroid>;
+
     specsForTextStyles(): Promise<{ [key: string]: TSFontForStyle }>;
     fontFromSpecs(specs?: TSFontSpecs): Promise<TSFontInfo>;
     fontFamilyNames(): Promise<string[]>;

--- a/index.d.ts
+++ b/index.d.ts
@@ -190,10 +190,25 @@ declare module "react-native-text-size" {
     heights: number[];
   }
 
+  export interface TSFlatHeightWithHasEllipsisOnAndroid {
+    heights: number[];
+    /** Only set on Android; will always be undefined on iOS */
+    hasEllipsisOnAndroid?: boolean[];
+  }
+
   interface TextSizeStatic {
     measure(params: TSMeasureParams): Promise<TSMeasureResult>;
     flatSizes(params: TSHeightsParams): Promise<TSFlatSizes>;
     flatHeights(params: TSHeightsParams): Promise<number[]>;
+    /**
+     * On Android, React Native renders text with slightly less space when
+     * it gets truncated with an ellipsis. As such, we add an alternate output
+     * that tells us whether each piece of text had an ellipsis added when it
+     * was rendered.
+     */
+    flatHeightsWithHasEllipsisOnAndroid(
+      params: TSHeightsParams,
+    ): Promise<TSFlatHeightWithHasEllipsisOnAndroid>;
     specsForTextStyles(): Promise<{ [key: string]: TSFontForStyle }>;
     fontFromSpecs(specs?: TSFontSpecs): Promise<TSFontInfo>;
     fontFamilyNames(): Promise<string[]>;

--- a/ios/RNTextSize.m
+++ b/ios/RNTextSize.m
@@ -169,6 +169,23 @@ RCT_EXPORT_METHOD(flatHeights:(NSDictionary * _Nullable)options
 }
 
 /**
+ * Given a set of text and styling for it, fetches all the height of
+ * the bounding box for that text. On Android, this function also resolves with
+ * an array with `hasEllipsisOnAndroid`. We don't need that on iOS, so we just
+ * return the heights with nothing else.
+ *
+ * Based on `RCTTextShadowViewMeasure` of Libraries/Text/Text/RCTTextShadowView.m
+ */
+RCT_EXPORT_METHOD(flatHeightsWithHasEllipsisOnAndroid:(NSDictionary * _Nullable)options
+                    resolver:(RCTPromiseResolveBlock)resolve
+                    rejecter:(RCTPromiseRejectBlock)reject)
+{
+  NSDictionary *const _Nullable sizes = [self flatSizesInner:options rejecter:reject];
+  if (sizes == nil) return;
+  resolve(@{ @"heights": sizes[@"heights"] });
+}
+
+/**
  * Resolve with an object with info about a font built with the parameters provided by
  * the user. Rejects if the parameters are falsy or the font could not be created.
  */

--- a/ios/RNTextSize.m
+++ b/ios/RNTextSize.m
@@ -169,23 +169,6 @@ RCT_EXPORT_METHOD(flatHeights:(NSDictionary * _Nullable)options
 }
 
 /**
- * Given a set of text and styling for it, fetches all the height of
- * the bounding box for that text. On Android, this function also resolves with
- * an array with `hasEllipsisOnAndroid`. We don't need that on iOS, so we just
- * return the heights with nothing else.
- *
- * Based on `RCTTextShadowViewMeasure` of Libraries/Text/Text/RCTTextShadowView.m
- */
-RCT_EXPORT_METHOD(flatHeightsWithHasEllipsisOnAndroid:(NSDictionary * _Nullable)options
-                    resolver:(RCTPromiseResolveBlock)resolve
-                    rejecter:(RCTPromiseRejectBlock)reject)
-{
-  NSDictionary *const _Nullable sizes = [self flatSizesInner:options rejecter:reject];
-  if (sizes == nil) return;
-  resolve(@{ @"heights": sizes[@"heights"] });
-}
-
-/**
  * Resolve with an object with info about a font built with the parameters provided by
  * the user. Rejects if the parameters are falsy or the font could not be created.
  */


### PR DESCRIPTION
## Motivation

While testing height measurement, I found that in React Native on Android, text rendered with `numberOfLines={x}` is 2 subpixels shorter when some text is truncated and replaced by ellipses.

We want to get this information from the react-native-text-size library if possible.

## Fix

1. Modify `flatHeights` function to adjust the height returned to be -2 / density shorter if truncated on Android

## Tested

1. Tested with code in the TextHeights.stories.tsx Storybook story in main repository on both Android/iOS and verified new function works.

![image](https://github.com/user-attachments/assets/f9329f81-e418-4197-97c8-551346625cfc)
